### PR TITLE
Small update

### DIFF
--- a/src/main/java/commands/CommandEnum.java
+++ b/src/main/java/commands/CommandEnum.java
@@ -33,7 +33,7 @@ public class CommandEnum {
         WHOIS(new WhoIs()),
         BOTSTATS(new BotStats()),
         LEVEL(new Level()),
-        CHANGEBOTPREFIX(new ChangeBotPrefix()),
+        CHANGEBOTPREFIXGUILD(new ChangeBotPrefixGuild()),
         PLAY(new Play()),
         JOIN(new Join()),
         LEAVE(new Leave()),
@@ -82,7 +82,8 @@ public class CommandEnum {
         AVATAR(new Avatar()),
         SETAMONGUSROLE(new SetAmongUsRole()),
         DM(new Dm()),
-        ROLEINFO(new RoleInfo());
+        ROLEINFO(new RoleInfo()),
+        CHANGEBOTPREFIXUSER(new ChangeBotPrefixUser());
         ICommand c;
 
         AllMyCommands(ICommand c) {
@@ -191,12 +192,23 @@ public class CommandEnum {
         return null;
     }
 
-    public String getShortHelpItem(String item) {
+    public EmbedBuilder getShortHelpItem(String item, String prefix) {
         for (AllMyCommands value : AllMyCommands.values()) {
             ICommand c = value.getCommand();
 
-            if (item.equals(c.getCommandAliases().get(0))) {
-                return c.getShortCommandDescription();
+            String commandFound = c.getCommandAliases().stream().filter(item::equalsIgnoreCase).findFirst().orElse(null);
+
+            if (commandFound != null) {
+                EmbedBuilder eb = new EmbedBuilder();
+
+                eb.setAuthor("Tais", "https://tijsbeek.nl", bot.getAvatarUrl());
+                eb.setTimestamp(Instant.now());
+
+                eb.setTitle("Error " + commandFound);
+                eb.addField("`" + prefix + c.getExampleCommand() + "`",  c.getShortCommandDescription(), true);
+
+                eb.setColor(getCurrentColor());
+                return eb;
             }
         }
         return null;

--- a/src/main/java/commands/CommandReceivedEvent.java
+++ b/src/main/java/commands/CommandReceivedEvent.java
@@ -92,13 +92,17 @@ public class CommandReceivedEvent {
 
         mentionsEveryone = message.mentionsEveryone();
 
-        command = messageAsString.replace(prefix, "").split(" ")[0];
-
         JDA = e.getJDA();
 
         DatabaseUser databaseUser = new DatabaseUser();
         userDB = databaseUser.getUserFromDBToUserDB(e.getAuthor().getId());
         isBotModerator = userDB.isBotModerator();
+
+        if (!userDB.getPrefix().equals("")) {
+            prefix = userDB.getPrefix();
+        }
+
+        command = messageAsString.replace(prefix, "").split(" ")[0];
     }
 
     public TextChannel getTextChannel() {
@@ -186,9 +190,13 @@ public class CommandReceivedEvent {
             return getFirstUserMentioned();
         } else {
             if (args[0].matches("[0-9]+")) {
-                User userInArg = getJDA().retrieveUserById(args[0]).complete();
-                if (!(userInArg == null)) {
-                    return userInArg;
+                try {
+                    User userInArg = getJDA().retrieveUserById(args[0]).complete();
+                    if (!(userInArg == null)) {
+                        return userInArg;
+                    }
+                } catch (NumberFormatException e) {
+                    return null;
                 }
             }
         }

--- a/src/main/java/commands/ICommand.java
+++ b/src/main/java/commands/ICommand.java
@@ -32,9 +32,16 @@ public interface ICommand {
 
     default MessageEmbed getFullHelp(String error, String prefix) {
         if (error.isEmpty()) {
-            return commandEnum.getFullHelpItem(commandAliases.get(0), prefix).build();
+            return commandEnum.getFullHelpItem(getCommandAliases().get(0), prefix).build();
         }
-        return commandEnum.getFullHelpItem(commandAliases.get(0), prefix).setDescription(error).build();
+        return commandEnum.getFullHelpItem(getCommandAliases().get(0), prefix).setDescription(error).build();
+    }
+
+    default MessageEmbed getShortHelp(String error, String prefix) {
+        if (error.isEmpty()) {
+            return commandEnum.getShortHelpItem(getCommandAliases().get(0), prefix).build();
+        }
+        return commandEnum.getShortHelpItem(getCommandAliases().get(0), prefix).setDescription("**" + error + "**").build();
     }
 
     String getCategory();

--- a/src/main/java/commands/bot/SetBlacklisted.java
+++ b/src/main/java/commands/bot/SetBlacklisted.java
@@ -4,6 +4,7 @@ import commands.CommandReceivedEvent;
 import commands.ICommand;
 import database.user.DatabaseUser;
 import database.user.UserDB;
+import net.dv8tion.jda.api.entities.User;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,9 +13,10 @@ public class SetBlacklisted implements ICommand {
     DatabaseUser databaseUser = new DatabaseUser();
     CommandReceivedEvent e;
 
+    User user;
     String userId;
 
-    ArrayList<String> commandAliases = new ArrayList<>(Arrays.asList("setblacklisted", "setblacklist"));
+    ArrayList<String> commandAliases = new ArrayList<>(Arrays.asList("setblacklisted", "setblacklist", "addblacklisted"));
     String category = "botmoderation";
     String exampleCommand = "setblacklisted <user id>/<user mention> <true/false>";
     String shortCommandDescription = "Set someone blacklisted from the bot.";
@@ -30,22 +32,14 @@ public class SetBlacklisted implements ICommand {
             return;
         }
 
-        String[] args = e.getArgs();
+        user = e.getFirstArgAsUser();
 
-        if (e.hasUserMentions()) {
-            userId = e.getFirstUserMentioned().getId();
-        } else {
-            if (args[0].matches("[0-9]+")) {
-                e.getJDA().retrieveUserById(args[0]).queue(user -> userId = args[0]);
-                if (userId.isEmpty()) {
-                    e.getMessageChannel().sendMessage(getFullHelp("That is not a valid user ID!", e.getPrefix())).queue();
-                    return;
-                }
-            } else {
-                e.getMessageChannel().sendMessage(getFullHelp("A user ID should only contain numbers!", e.getPrefix())).queue();
-                return;
-            }
+        if (user == null) {
+            e.getMessageChannel().sendMessage(getShortHelp("Requires a valid user ID!", e.getPrefix())).queue();
+            return;
         }
+
+        userId = user.getId();
 
         UserDB userDB = databaseUser.getUserFromDBToUserDB(userId);
 
@@ -54,7 +48,7 @@ public class SetBlacklisted implements ICommand {
             return;
         }
 
-        databaseUser.setBlacklisted(userId, Boolean.parseBoolean(args[1]));
+        databaseUser.setBlacklisted(userId, Boolean.parseBoolean(e.getArgs()[1]));
     }
 
     @Override

--- a/src/main/java/commands/bot/SetBotModerator.java
+++ b/src/main/java/commands/bot/SetBotModerator.java
@@ -3,6 +3,7 @@ package commands.bot;
 import commands.CommandReceivedEvent;
 import commands.ICommand;
 import database.user.DatabaseUser;
+import net.dv8tion.jda.api.entities.User;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,6 +12,7 @@ public class SetBotModerator implements ICommand {
     DatabaseUser databaseUser = new DatabaseUser();
     CommandReceivedEvent e;
 
+    User user;
     String userId;
 
     ArrayList<String> commandAliases = new ArrayList<>(Arrays.asList("setbotmoderator", "setbotmoderator", "addbotmoderator"));
@@ -29,24 +31,16 @@ public class SetBotModerator implements ICommand {
             return;
         }
 
-        String[] args = e.getArgs();
+        user = e.getFirstArgAsUser();
 
-        if (e.hasUserMentions()) {
-            userId = e.getFirstUserMentioned().getId();
-        } else {
-            if (args[0].matches("[0-9]+")) {
-                e.getJDA().retrieveUserById(args[0]).queue(user -> userId = args[0]);
-                if (userId.isEmpty()) {
-                    e.getMessageChannel().sendMessage(getFullHelp("That is not a valid user ID!", e.getPrefix())).queue();
-                    return;
-                }
-            } else {
-                e.getMessageChannel().sendMessage(getFullHelp("A user ID should only contain numbers!", e.getPrefix())).queue();
-                return;
-            }
+        if (user == null) {
+            e.getMessageChannel().sendMessage(getShortHelp("Requires a valid user ID!", e.getPrefix())).queue();
+            return;
         }
 
-        databaseUser.setBotModerator(userId, Boolean.parseBoolean(args[1]));
+        userId = user.getId();
+
+        databaseUser.setBotModerator(userId, Boolean.parseBoolean(e.getArgs()[1]));
     }
 
     @Override

--- a/src/main/java/commands/util/ChangeBotPrefixGuild.java
+++ b/src/main/java/commands/util/ChangeBotPrefixGuild.java
@@ -3,17 +3,20 @@ package commands.util;
 import commands.CommandReceivedEvent;
 import commands.ICommand;
 import database.guild.DatabaseGuild;
+import database.guild.GuildDB;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
-public class ChangeBotPrefix implements ICommand {
+public class ChangeBotPrefixGuild implements ICommand {
     CommandReceivedEvent e;
     DatabaseGuild databaseGuild = new DatabaseGuild();
 
-    ArrayList<String> commandAliases = new ArrayList<>(Arrays.asList("setbotprefix", "botprefix", "changebotprefix"));
+    GuildDB guildDB;
+
+    ArrayList<String> commandAliases = new ArrayList<>(Arrays.asList("changebotprefixguild", "setbotprefixserver", "changebotprefixserver", "botprefixserver"));
     String category = "util";
-    String exampleCommand = "setbotprefix <botprefix>";
+    String exampleCommand = "changebotprefixguild <botprefix>";
     String shortCommandDescription = "Set the prefix of the bot in this guild.";
     String fullCommandDescription = "Set the prefix of the bot in this guild.";
 
@@ -28,19 +31,19 @@ public class ChangeBotPrefix implements ICommand {
             return;
         }
 
-        String guildID = e.getGuild().getId();
-
-        String currentPrefix = databaseGuild.getPrefixGuildInDB(guildID);
-
         if (!e.hasArgs()) {
             e.getMessageChannel().sendMessage(getFullHelp("Requires at least 1 argument", e.getPrefix())).queue();
             return;
         }
 
-        String toReplace = currentPrefix + e.getCommand() + " ";
-        String messageRaw = e.getMessage().getContentRaw();
-        prefix = messageRaw.replace(toReplace, "");
-        databaseGuild.setPrefixGuildInDB(guildID, prefix);
+        guildDB = e.getGuildDB();
+
+        prefix = e.getMessageWithoutCommand();
+
+        guildDB.setPrefix(prefix);
+
+        databaseGuild.updateGuildInDB(guildDB);
+
         e.getMessageChannel().sendMessage("Prefix changed to: " + prefix).queue();
     }
 

--- a/src/main/java/commands/util/ChangeBotPrefixUser.java
+++ b/src/main/java/commands/util/ChangeBotPrefixUser.java
@@ -1,0 +1,67 @@
+package commands.util;
+
+import commands.CommandReceivedEvent;
+import commands.ICommand;
+import database.guild.DatabaseGuild;
+import database.user.DatabaseUser;
+import database.user.UserDB;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class ChangeBotPrefixUser implements ICommand {
+    CommandReceivedEvent e;
+    DatabaseUser databaseUser = new DatabaseUser();
+    UserDB userDB;
+
+    ArrayList<String> commandAliases = new ArrayList<>(Arrays.asList("changebotprefixuser", "setbotprefixuser", "changebotprefixuser", "botprefixuser"));
+    String category = "util";
+    String exampleCommand = "changebotprefixuser <botprefix>";
+    String shortCommandDescription = "Set the prefix of the bot for you.";
+    String fullCommandDescription = "Set the prefix of the bot for you.";
+
+    @Override
+    public void command(CommandReceivedEvent event) {
+        e = event;
+
+        if (!e.hasArgs()) {
+            e.getMessageChannel().sendMessage(getFullHelp("Requires at least 1 argument", e.getPrefix())).queue();
+            return;
+        }
+
+        userDB = e.getUserDB();
+
+        String prefix = e.getMessageWithoutCommand();
+
+        userDB.setPrefix(prefix);
+
+        databaseUser.updateUserInDB(userDB);
+
+        e.getMessageChannel().sendMessage("Personal prefix changed to: " + prefix).queue();
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public String getExampleCommand() {
+        return exampleCommand;
+    }
+
+    @Override
+    public String getShortCommandDescription() {
+        return shortCommandDescription;
+    }
+
+    @Override
+    public String getFullCommandDescription() {
+        return fullCommandDescription;
+    }
+
+    @Override
+    public ArrayList<String> getCommandAliases() {
+        return commandAliases;
+    }
+}

--- a/src/main/java/database/user/UserDB.java
+++ b/src/main/java/database/user/UserDB.java
@@ -1,6 +1,5 @@
 package database.user;
 
-import java.util.HashMap;
 import java.util.Random;
 
 public class UserDB {
@@ -11,47 +10,39 @@ public class UserDB {
 
     long lastTimeRepGiven;
 
-    int reps = 0;
-
     boolean isBotModerator = false;
     boolean isBlackListed = false;
 
-    HashMap<Integer, String> todo = new HashMap<>();
+    int reps = 0;
+
+    String prefix = "";
 
     public UserDB(String userID) {
         this.userID = userID;
     }
 
-    public UserDB(String userID, int level, int xp, int reps) {
+    public UserDB(String userID, int level, int xp, int reps, boolean isBotModerator, boolean isBlackListed) {
         this.userID = userID;
         this.level = level;
         this.xp = xp;
         this.reps = reps;
-    }
-
-    public UserDB(String userID, int level, int xp, boolean isBotModerator, boolean isBlackListed) {
-        this.userID = userID;
-        this.level = level;
-        this.xp = xp;
         this.isBotModerator = isBotModerator;
         this.isBlackListed = isBlackListed;
     }
 
-    public void addXp(int xp) {
-        this.xp += xp;
+    public UserDB(String userID, int level, int xp, int reps, boolean isBotModerator, boolean isBlackListed, String prefix) {
+        this.userID = userID;
+        this.level = level;
+        this.xp = xp;
+        this.reps = reps;
+        this.isBotModerator = isBotModerator;
+        this.isBlackListed = isBlackListed;
+        this.prefix = prefix;
     }
 
     public void addRandomXp() {
         Random random = new Random();
         xp = xp + random.nextInt(20);
-    }
-
-    public void setLevel(int level) {
-        this.level = level;
-    }
-
-    public void setXp(int xp) {
-        this.xp = xp;
     }
 
     public String getUserID() {
@@ -117,5 +108,13 @@ public class UserDB {
 
     public void setLastTimeRepGiven() {
         this.lastTimeRepGiven = System.currentTimeMillis();
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
     }
 }


### PR DESCRIPTION
Added 1 command

ChangeBotPrefixUser, a user can set their own bot prefix that works across all guilds.

Did a small rework of the ChangeBotPrefixGuild command

It was manually getting the full command without prefix and command. While I've CommandReceivedEvent#getMessageWithoutCommand

The GuildDB object is also included to the event, no need for contacting the database twice.

Also changed the SetBlacklisted and SetBotModerator command so it uses my CommandReceivedEvent#getFirstArgAsUser

Added error help that's a shorter version of a FullHelp, that has a little more clear a error.

Removed unused methods from DatabaseUser

A really small change, but still want to do something.